### PR TITLE
fix: sign up 시 user 먼저 save 후 update password history

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,8 +23,6 @@ repositories {
 val kotestVersion = "5.7.2"
 val mockkVersion = "1.13.9"
 val queryDslVersion = "5.0.0"
-val kotestVersion = "5.5.5"
-val mockkVersion = "1.13.8"
 
 
 dependencies {

--- a/src/main/kotlin/com/example/backoffice/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/example/backoffice/domain/user/service/UserService.kt
@@ -33,9 +33,9 @@ class UserService(
             password = encodedPassword,
             imageUrl = imageUrl
         )
-
-        passwordHistoryService.updatePasswordHistory(user)
-        return userRepository.save(user).run { SignUpResponse(userId = id!!) }
+        return userRepository.save(user)
+            .also { passwordHistoryService.updatePasswordHistory(it) }
+            .run { SignUpResponse(userId = id!!) }
     }
 
     fun login(request: LoginRequest): LoginResponse {


### PR DESCRIPTION
### 변경 사항
- usreId가 없는데 passwordHistory를 save해서 에러가 발생하였습니다.
- user를 먼저 save하도록 변경하였습니다.

### 연관 이슈
- #58 
